### PR TITLE
Added global object wpsmartcrop to make plugin methods accessible

### DIFF
--- a/wp-smartcrop/js/image-renderer.js
+++ b/wp-smartcrop/js/image-renderer.js
@@ -1,3 +1,5 @@
+wpsmartcrop = {};
+
 jQuery(document).ready(function($) {
 	var browser_supports_object_fit = (function() { // immediately invoked
 		// HACK -- CURRENT iOS SAFARI AND CHROME HAVE RENDERING ISSUES WITH OBJECTFIT
@@ -16,7 +18,7 @@ jQuery(document).ready(function($) {
 		return false;
 	})();
 
-	function closest( num, arr ) {
+	wpsmartcrop.closest = function ( num, arr ) {
 		var curr = arr[0];
 		var diff = Math.abs( num - curr );
 		for( var val = 0; val < arr.length; val++ ) {
@@ -27,9 +29,9 @@ jQuery(document).ready(function($) {
 			}
 		}
 		return curr;
-	}
+	};
 
-	function get_final_image_dims( natural_dims, target_dims ) {
+	wpsmartcrop.get_final_image_dims = function ( natural_dims, target_dims ) {
 		var natural_ratio = natural_dims[0]/natural_dims[1];
 		var target_ratio  = target_dims[0]/target_dims[1];
 		if( natural_ratio > target_ratio ) {
@@ -42,13 +44,13 @@ jQuery(document).ready(function($) {
 			target_dims[0],
 			Math.round(target_dims[0] / natural_ratio)
 		];
-	}
+	};
 
-	function get_crop_data($el) {
+	wpsmartcrop.get_crop_data = function ($el) {
 		var get_smartcrop_offset = function(dim, orig_dim, focus_pos) {
-			var power_lines = [.33333, .5, .66667];
+			var power_lines = [0.33333, 0.5, 0.66667];
 			focus_pos = focus_pos / 100;
-			var focus_target = closest(focus_pos, power_lines);
+			var focus_target = wpsmartcrop.closest(focus_pos, power_lines);
 			var offset = Math.round(focus_pos * orig_dim - focus_target * dim);
 			var max = orig_dim - dim;
 			if(offset > max) {
@@ -58,7 +60,7 @@ jQuery(document).ready(function($) {
 				offset = 0;
 			}
 			return -1 * offset;
-		}
+		};
 		var focal_point  = $el.data('smartcrop-focus');
 		var natural_dims = [
 			( $el[0].naturalWidth  ) ? $el[0].naturalWidth  : $el[0].getAttribute('width'),
@@ -73,8 +75,8 @@ jQuery(document).ready(function($) {
 		    !target_dims[0] || !target_dims[1] ) {
 			return false;
 		}
-		var final_dims = get_final_image_dims( natural_dims, target_dims );
-		var offsets = [0,0]
+		var final_dims = wpsmartcrop.get_final_image_dims( natural_dims, target_dims );
+		var offsets = [0,0];
 		if( target_dims[0]/target_dims[1] < final_dims[0]/final_dims[1] ) {
 			offsets[0] = get_smartcrop_offset(target_dims[0], final_dims[0], focal_point[0]);
 		} else {
@@ -86,9 +88,10 @@ jQuery(document).ready(function($) {
 			offset_x     : offsets[0],
 			offset_y     : offsets[1]
 		};
-	}
-	function recrop_images( $el ) {
-		var crop = get_crop_data($el);
+	};
+
+	wpsmartcrop.recrop_images = function ( $el ) {
+		var crop = wpsmartcrop.get_crop_data( $el );
 		// for browsers that support object-position and object-fit
 		if( browser_supports_object_fit ) {
 			var position_val = '' + crop.offset_x + 'px ' + '' + crop.offset_y + 'px';
@@ -115,27 +118,32 @@ jQuery(document).ready(function($) {
 			});
 			$overlay.addClass('wpsmartcrop-overlay-rendered');
 		}
-	}
-	$('img.wpsmartcrop-image').each(function() {
-		var $this = $(this);
-		$this.next('wpsmartcrop-overlay').remove();
-		var natural_dims  = [
-			( $this[0].naturalWidth  ) ? $this[0].naturalWidth  : $this[0].getAttribute('width'),
-			( $this[0].naturalHeight ) ? $this[0].naturalHeight : $this[0].getAttribute('height')
-		];
-		$this.data( 'wpsmartcrop-natural-dims', natural_dims );
-		if( !browser_supports_object_fit ) {
-			var $clone = $this.clone().removeClass('wpsmartcrop-image').removeAttr('data-smartcrop-focus');
-			var $image_overlay = $('<div></div>').addClass('wpsmartcrop-overlay').append($clone);
-			$image_overlay.insertAfter($this);
-		}
-		recrop_images( $this );
-		var resizer_timeout = false;
-		$(window).resize(function() {
-			clearTimeout( resizer_timeout );
-			resizer_timeout = setTimeout(function() {
-				recrop_images( $this );
-			}, 50);
-		});
-	});
+	};
+
+    wpsmartcrop.start = function () {
+    	$( 'img.wpsmartcrop-image' ).each(function() {
+    		var $this = $(this);
+    		$this.next('wpsmartcrop-overlay').remove();
+    		var natural_dims  = [
+    			( $this[0].naturalWidth  ) ? $this[0].naturalWidth  : $this[0].getAttribute('width'),
+    			( $this[0].naturalHeight ) ? $this[0].naturalHeight : $this[0].getAttribute('height')
+    		];
+    		$this.data( 'wpsmartcrop-natural-dims', natural_dims );
+    		if( !browser_supports_object_fit ) {
+    			var $clone = $this.clone().removeClass('wpsmartcrop-image').removeAttr('data-smartcrop-focus');
+    			var $image_overlay = $('<div></div>').addClass('wpsmartcrop-overlay').append($clone);
+    			$image_overlay.insertAfter($this);
+    		}
+    		wpsmartcrop.recrop_images( $this );
+    		var resizer_timeout = false;
+    		$(window).resize(function() {
+    			clearTimeout( resizer_timeout );
+    			resizer_timeout = setTimeout(function() {
+    				wpsmartcrop.recrop_images( $this );
+    			}, 50);
+    		});
+    	});
+    };
+
+    wpsmartcrop.start();
 });


### PR DESCRIPTION
Adding a global object `wpsmartcop` the **image-renderer.js** methods will be acessible for other plugins or themes, making possible to call the methods later, for example, if you load posts trough AJAX, calling the methods after the posts are loaded.