### PR TITLE
Fix php notice in php 7.4 when settings aren't saved yet

### DIFF
--- a/wp-smartcrop/wp-smartcrop.php
+++ b/wp-smartcrop/wp-smartcrop.php
@@ -410,7 +410,7 @@ if( !class_exists('WP_Smart_Crop') ) {
 			wp_enqueue_script( 'jquery' );
 			wp_enqueue_script( 'jquery.wp-smartcrop', $this->plugin_dir_url . 'js/jquery.wp-smartcrop.min.js', array( 'jquery' ), $this->version, true );
 			wp_localize_script( 'jquery.wp-smartcrop', 'wpsmartcrop_options', array(
-				'focus_mode' => $this->options['focus-mode']
+				'focus_mode' => ( is_array($this->options) && !empty($this->options['focus-mode']) ) ? $this->options['focus-mode'] : 'power-lines'
 			) );
 			wp_enqueue_style( 'wp-smart-crop-renderer', $this->plugin_dir_url . 'css/image-renderer.css', array(), $this->version );
 		}


### PR DESCRIPTION
Fix a PHP Notice in `smartcrop/wp-smartcrop.php` with PHP 7.4 when settings aren't saved yet into the database.

Issue was mentioned in the two support topics below (related to each other).

https://wordpress.org/support/topic/type-check-error-for-plugin-settings-options-in-php-7-4-3/
and
https://wordpress.org/support/topic/issue-on-php-7-4-trying-to-access-array-offset-on-value-of-type-bool/