### PR TITLE
Remove o-object-fit as it does not exist

### DIFF
--- a/wp-smartcrop/css/image-renderer.css
+++ b/wp-smartcrop/css/image-renderer.css
@@ -2,7 +2,6 @@ img.wpsmartcrop-image {
 	opacity      : 0;
 	transition   : opacity 0.2s;
 	overflow     : hidden;
-	o-object-fit : cover;
 	object-fit   : cover;
 }
 img.wpsmartcrop-image.wpsmartcrop-rendered {


### PR DESCRIPTION
No such property. Throws error in HTML validator.

![Screen-Shot-2023-05-16-11-17-09 51](https://github.com/BytesCo/wpsmartcrop/assets/1534150/5659d9cb-7200-4277-b3bb-3b58f082f586)
